### PR TITLE
Don't manage an unrelated proxy script

### DIFF
--- a/manifests/git.pp
+++ b/manifests/git.pp
@@ -40,10 +40,6 @@ class setproxy::git (
       content => template('setproxy/gitproxy.erb'),
       mode    => '0755',
     }
-  } else {
-    file { '/etc/profile.d/proxy.sh':
-      ensure  => absent,
-    }
   }
 }
 


### PR DESCRIPTION
The git proxy setting class manages those proxy settings through
git-specific files, so it does not make sense for it to do anything
with the /etc/profile.d/proxy.sh since it is unrelated.
 Fixes #1 
